### PR TITLE
Add Ponelope indicator onboarding doc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@
    db_data/index-usage-byov.md
    db_control/collections.md
    inference/inference-api.md
+   onboarding/ponelope-indicator.md
 
 ===================
 Pinecone Python SDK

--- a/docs/onboarding/ponelope-indicator.md
+++ b/docs/onboarding/ponelope-indicator.md
@@ -1,0 +1,24 @@
+# Ponelope Indicator Onboarding
+
+This guide describes how to use a Tally form to onboard investors interested in purchasing the Ponelope trading indicator for TradingView.
+
+## Creating the Tally Form
+
+1. Go to [Tally](https://tally.so) and create a new form.
+2. Add fields to collect investor contact details, TradingView username, and preferred subscription plan.
+3. Include a section describing the benefits of the Ponelope indicator for TradingView users.
+4. Configure form submission to send confirmations to both the investor and your sales team.
+
+## Embedding the Form
+
+Once the form is published, you can share the form link directly or embed it on your website using the embed script provided by Tally.
+
+```html
+<!-- Example embed code -->
+<iframe data-tally-src="https://tally.so/r/your-form-id" loading="lazy" width="100%" height="800" frameborder="0" marginheight="0" marginwidth="0" title="Ponelope Indicator Form"></iframe>
+```
+
+## Next Steps
+
+After collecting investor information, reach out via email to provide payment details and instructions for enabling the Ponelope indicator within TradingView.
+


### PR DESCRIPTION
## Summary
- add Ponelope indicator onboarding instructions under docs/onboarding
- link the doc from the main documentation index

## Testing
- `poetry run ruff check --fix`
- `poetry run ruff format`
- `poetry run mypy pinecone` *(fails: missing stub packages)*
- `poetry run pytest tests/unit` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_6883ef7b113c83238f123a6cd03f58d6